### PR TITLE
Fix annotation type descriptions in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,8 +85,8 @@ Any unlisted prop will be pass to the component so you can use any react prop to
 | box            | This style draws a box around the element               |
 | circle         | Draw a circle around the element                        |
 | highlight      | Creates a highlight effect as if maked by a highlighter |
-| strike-through | This style draws a box around the element               |
-| crossed-off    | This style draws a box around the element               |
+| strike-through | Draws a horizontal line over the element                |
+| crossed-off    | Crosses out the element with two diagonal lines         |
 
 ### Updating Styles
 


### PR DESCRIPTION
I am using this library for my portfolio website and while going through the docs, I got confused about the descriptions of last 2 annotation types as they did not make sense to me:
* `striked-through`
* `crossed-off`

Maybe updating their descriptions was missed when adding support for those options.

In this PR, I am updating those descriptions with concise but detailed-enough explanations following the style of the other descriptions.